### PR TITLE
Fix signature dependency on fingerprint value (seperate the author name and key id).

### DIFF
--- a/src/main/java/cz/muni/crocs/appletstore/StoreItemInfo.java
+++ b/src/main/java/cz/muni/crocs/appletstore/StoreItemInfo.java
@@ -115,7 +115,7 @@ public class StoreItemInfo extends HintPanel {
                         fireInstall(appletName, getInfoPack(dataSet, latestV,
                                 sdks, sdks.size() - 1),
                                 dataSet.get(JsonParser.TAG_PGP_SIGNER).getAsString(),
-                                dataSet.get(JsonParser.TAG_PGP_IDENTIFIER).getAsString(),
+                                dataSet.get(JsonParser.TAG_PGP_FINGERPRINT).getAsString(),
                                 dataSet.get(JsonParser.TAG_APPLET_INSTANCE_NAMES),
                                 callback,
                                 installed && OptionsFactory.getOptions().is(Options.KEY_SIMPLE_USE),
@@ -219,7 +219,7 @@ public class StoreItemInfo extends HintPanel {
                         fireInstall(dataSet.get(JsonParser.TAG_NAME).getAsString(),
                                 getInfoPack(dataSet, version, sdks, compilerIdx),
                                 dataSet.get(JsonParser.TAG_PGP_SIGNER).getAsString(),
-                                dataSet.get(JsonParser.TAG_PGP_IDENTIFIER).getAsString(),
+                                dataSet.get(JsonParser.TAG_PGP_FINGERPRINT).getAsString(),
                                 dataSet.get(JsonParser.TAG_APPLET_INSTANCE_NAMES),
                                 call,
                                 installed && OptionsFactory.getOptions().is(Options.KEY_SIMPLE_USE),
@@ -318,7 +318,7 @@ public class StoreItemInfo extends HintPanel {
                 appletName + Config.S + appletName + "_v" + version + "_sdk" + sdkVersion + ".cap";
     }
 
-    private static void fireInstall(String name, AppletInfo info, String signer, String identifier, JsonElement appNames,
+    private static void fireInstall(String name, AppletInfo info, String signer, String fingerprint, JsonElement appNames,
                                     OnEventCallBack<Void, Void> call, boolean installed,
                                     String defaultSelected, MouseEvent e) {
 
@@ -342,7 +342,7 @@ public class StoreItemInfo extends HintPanel {
         }
 
         new InstallAction(new InstallBundle(info.getName() + info.getVersion() + ", sdk " + info.getSdk(),
-                info, file, signer, identifier, appletNamesData), installed, defaultSelected, call).mouseClicked(e);
+                info, file, signer, fingerprint, appletNamesData), installed, defaultSelected, call).mouseClicked(e);
     }
 
     private JButton getButton(String translationKey, Color background) {

--- a/src/main/java/cz/muni/crocs/appletstore/action/InstallAction.java
+++ b/src/main/java/cz/muni/crocs/appletstore/action/InstallAction.java
@@ -104,10 +104,10 @@ public class InstallAction extends CardAbstractAction {
             void work() {
                 final Signature signature = new SignatureImpl();
                 try {
-                    result = signature.verifyPGPAndReturnMessage("JCAppStore", data.getCapfile());
+                    result = signature.verifyPGPAndReturnMessage(data.getCapfile());
                     if (data.getSigner() != null && !data.getSigner().isEmpty()) {
-                        Tuple<Integer, String> another =
-                                signature.verifyPGPAndReturnMessage(data.getSigner(), data.getCapfile());
+                        Tuple<Integer, String> another = signature.verifyPGPAndReturnMessage(data.getFingerprint(),
+                                data.getCapfile(), signature.getSignatureFileFromString(data.getSigner(), data.getCapfile().getAbsolutePath()));
                         result = new Tuple<>(another.first,
                                 "JCAppStore: " + result.second + "<br>" + data.getSigner() + ": " + another.second);
                     }

--- a/src/main/java/cz/muni/crocs/appletstore/action/InstallBundle.java
+++ b/src/main/java/cz/muni/crocs/appletstore/action/InstallBundle.java
@@ -16,19 +16,19 @@ public class InstallBundle {
     private AppletInfo info;
     private File capfile;
     private String signer;
-    private String identifier;
+    private String fingerprint;
     private ArrayList<String> appletNames;
 
-    public InstallBundle(String titleBar, AppletInfo info, File capfile, String signer, String identifier) {
+    public InstallBundle(String titleBar, AppletInfo info, File capfile, String signer, String fingerprint) {
         this.titleBar = titleBar;
         this.info = info;
         this.capfile = capfile;
         this.signer = signer;
-        this.identifier = identifier;
+        this.fingerprint = fingerprint;
     }
 
-    public InstallBundle(String titleBar, AppletInfo info, File capfile, String signer, String identifier, ArrayList<String> appletNames) {
-        this(titleBar, info, capfile, signer, identifier);
+    public InstallBundle(String titleBar, AppletInfo info, File capfile, String signer, String fingerprint, ArrayList<String> appletNames) {
+        this(titleBar, info, capfile, signer, fingerprint);
         this.appletNames = appletNames;
     }
 
@@ -52,8 +52,8 @@ public class InstallBundle {
         return signer;
     }
 
-    public String getIdentifier() {
-        return identifier;
+    public String getFingerprint() {
+        return fingerprint;
     }
 
     public void setCapfile(File file) {

--- a/src/main/java/cz/muni/crocs/appletstore/crypto/PGP.java
+++ b/src/main/java/cz/muni/crocs/appletstore/crypto/PGP.java
@@ -68,12 +68,12 @@ public class PGP extends CmdTask {
 
     /**
      * Verify signature
-     * @param author author - signature key owner identifier as showin in PGP or null
+     * @param fingerprint - key identifier or null
      * @param file file to verify
      * @param signatureFile detached signature file
      * @return 0 if ok, 1 if invalid, 2 if error occured
      */
-    int verifySignature(String author, File file, File signatureFile) throws LocalizedSignatureException {
+    int verifySignature(String fingerprint, File file, File signatureFile) throws LocalizedSignatureException {
         int counter = 0;
         while (!Files.isReadable(file.toPath()) || !Files.isReadable(signatureFile.toPath())) {
             try {
@@ -100,32 +100,32 @@ public class PGP extends CmdTask {
         logger.info(output);
         output = output.replaceAll("\\s", "");
 
-        if (author == null) {
+        if (fingerprint == null) {
             return (output.contains(OptionsFactory.getOptions().getOption(Options.KEY_STORE_FINGERPRINT)))
                     ? sig.exitValue() : 1;
         }
-        return (output.contains(author)) ? sig.exitValue() : 1;
+        return (output.contains(fingerprint.replaceAll("\\s", ""))) ? sig.exitValue() : 1;
     }
 
     /**
      * Just a wrapper that assesses int output from verifySignature()
      * @return tuple: first: forwards exit code value; second: string message to display
      */
-    Tuple<Integer, String> verifySignatureAndGetErrorMsg(String author, File file, File signatureFile)
+    Tuple<Integer, String> verifySignatureAndGetErrorMsg(String fingerprint, File file, File signatureFile)
             throws LocalizedSignatureException {
         if (!file.exists() || !signatureFile.exists())
             return new Tuple<>(3, textSrc.getString("H_no_file_pgp"));
-        int exitCode = verifySignature(author, file, signatureFile);
+        int exitCode = verifySignature(fingerprint, file, signatureFile);
         switch (exitCode) {
             case 0: {
-                if (author == null) {
+                if (fingerprint == null) {
                     return new Tuple<>(exitCode, textSrc.getString("H_verified_no_author"));
                 /*TODO cannot find out missing trust set on the key, so the message will be
                    "succeeded" even though key not trusted*/
                  /*new Tuple<>("verify_trust.png", textSrc.getString("H_verified_no_author") +
                         textSrc.getString("H_verified_not_trusted"))*/
                 } else {
-                    return new Tuple<>(exitCode, textSrc.getString("H_verified") + author);
+                    return new Tuple<>(exitCode, textSrc.getString("H_verified_key") + fingerprint);
                     /*TODO cannot find out missing trust set on the key*/
                 /*new Tuple<>("verify_trust.png", textSrc.getString("H_verified") + author +
                         textSrc.getString("H_verified_not_trusted")) */

--- a/src/main/java/cz/muni/crocs/appletstore/crypto/Signature.java
+++ b/src/main/java/cz/muni/crocs/appletstore/crypto/Signature.java
@@ -15,7 +15,7 @@ public interface Signature {
     final String storeAuthor = "JCAppStore";
 
     default File getSignatureFileFromString(String author, String filename) {
-        if (author != null && author.equals(storeAuthor))
+        if (author == null || author.equals(storeAuthor))
             return new File(filename + ".sig");
         return new File(filename + "." + author + ".sig");
     }
@@ -32,7 +32,7 @@ public interface Signature {
 
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with auto author deduction using Keybase
      * @param author author of the file
      * @param file path to the file to verify
      * @param fileSignature path to the signature file of the file
@@ -41,7 +41,7 @@ public interface Signature {
     boolean verify(String author, String file, String fileSignature) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with auto author deduction using Keybase
      * @param author author of the file
      * @param file file to verify
      * @param fileSignature signature of the file
@@ -50,27 +50,27 @@ public interface Signature {
     boolean verify(String author, File file, File fileSignature) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature
-     * @param author author of the file
+     * Verify the file signature using PGP
+     * @param fingerprint signature key fingerprint or null of store key
      * @param file path to the file to verify
      * @param fileSignature path to the signature file of the file
      * @return true if file signature verified
      * @throws LocalizedSignatureException when signature fails for reasons such as wrong parameters, failed to obrain key...
      */
-    boolean verifyPGP(String author, String file, String fileSignature) throws LocalizedSignatureException;
+    boolean verifyPGP(String fingerprint, String file, String fileSignature) throws LocalizedSignatureException;
 
     /**
      * Verify the file signature
-     * @param author author of the file
+     * @param fingerprint of the signature key or null if store key
      * @param file file to verify
      * @param fileSignature the signature file of the file
      * @return true if file signature verified
      * @throws LocalizedSignatureException when signature fails for reasons such as wrong parameters, failed to obtain key...
      */
-    boolean verifyPGP(String author, File file, File fileSignature) throws LocalizedSignatureException;
+    boolean verifyPGP(String fingerprint, File file, File fileSignature) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with auto author deduction using Keybase
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
@@ -81,7 +81,7 @@ public interface Signature {
     Tuple<Integer, String> verifyAndReturnMessage(String author, String file) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with auto author deduction using Keybase
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
@@ -92,27 +92,25 @@ public interface Signature {
     Tuple<Integer, String> verifyAndReturnMessage(String author, File file) throws LocalizedSignatureException;
 
     /**
+     * Verify the store signature using PGP
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
-     * verifies the internet connection and returns error message if not accessible
-     * @param author author of the file
      * @param file path to the file to verify
      * @return tuple with first = exit code, second = message
      */
-    Tuple<Integer, String> verifyPGPAndReturnMessage(String author, String file) throws LocalizedSignatureException;
+    Tuple<Integer, String> verifyPGPAndReturnMessage(String file) throws LocalizedSignatureException;
 
     /**
+     * Verify the store signature using PGP
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
-     * verifies the internet connection and returns error message if not accessible
-     * @param author author of the file
-     * @param file file to verify
+     * @param file path to the file to verify
      * @return tuple with first = exit code, second = message
      */
-    Tuple<Integer, String> verifyPGPAndReturnMessage(String author, File file) throws LocalizedSignatureException;
+    Tuple<Integer, String> verifyPGPAndReturnMessage(File file) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with Keybase: auto author deduction
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
@@ -123,7 +121,7 @@ public interface Signature {
     Tuple<Integer, String> verifyAndReturnMessage(String author, String file, String detachedSignature) throws LocalizedSignatureException;
 
     /**
-     * Verify the file signature with auto author deduction
+     * Verify the file signature with Keybase: auto author deduction
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
@@ -134,23 +132,24 @@ public interface Signature {
     Tuple<Integer, String> verifyAndReturnMessage(String author, File file, File detachedSignature) throws LocalizedSignatureException;
 
     /**
+     * Verify the store signature using PGP
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
-     * @param author author of the file
+     * @param fingerprint signature key fingerprint or null if store signature
      * @param file path to the file to verify
      * @return tuple with first = exit code, second = message
      */
-    Tuple<Integer, String> verifyPGPAndReturnMessage(String author, String file, String detachedSignature) throws LocalizedSignatureException;
+    Tuple<Integer, String> verifyPGPAndReturnMessage(String fingerprint, String file, String detachedSignature) throws LocalizedSignatureException;
 
     /**
+     * Verify the store signature using PGP
      * supposes that the signature is stored within the same directory as 'file' and its name is '[file].sig'
      * takes care of the situation if files do not exist and reproduces the message error
      * verifies the internet connection and returns error message if not accessible
-     * @param author author of the file
+     * @param fingerprint signature key fingerprint or null if store signature
      * @param file file to verify
      * @return tuple with first = exit code, second = message
      */
-    Tuple<Integer, String> verifyPGPAndReturnMessage(String author, File file, File detachedSignature) throws LocalizedSignatureException;
-
+    Tuple<Integer, String> verifyPGPAndReturnMessage(String fingerprint, File file, File detachedSignature) throws LocalizedSignatureException;
 }

--- a/src/main/java/cz/muni/crocs/appletstore/crypto/SignatureImpl.java
+++ b/src/main/java/cz/muni/crocs/appletstore/crypto/SignatureImpl.java
@@ -30,12 +30,12 @@ public class SignatureImpl implements Signature {
     }
 
     @Override
-    public boolean verifyPGP(String author, String file, String fileSignature) throws LocalizedSignatureException {
+    public boolean verifyPGP(String fingerprint, String file, String fileSignature) throws LocalizedSignatureException {
         File code = new File(file);
         throwIfNotExists(code);
         File signature = new File(fileSignature);
         throwIfNotExists(signature);
-        return verifyPGP(author, code, signature);
+        return verifyPGP(fingerprint, code, signature);
     }
 
     @Override
@@ -54,13 +54,13 @@ public class SignatureImpl implements Signature {
     }
 
     @Override
-    public Tuple<Integer, String> verifyPGPAndReturnMessage(String author, String file) throws LocalizedSignatureException {
-        return verifyPGPAndReturnMessage(author, new File(file));
+    public Tuple<Integer, String> verifyPGPAndReturnMessage(String file) throws LocalizedSignatureException {
+        return verifyPGPAndReturnMessage(new File(file));
     }
 
     @Override
-    public Tuple<Integer, String> verifyPGPAndReturnMessage(String author, File file)  throws LocalizedSignatureException {
-        return verifyPGPAndReturnMessage(author, file, getSignatureFileFromString(author, file.getAbsolutePath()));
+    public Tuple<Integer, String> verifyPGPAndReturnMessage(File file)  throws LocalizedSignatureException {
+        return verifyPGPAndReturnMessage(null, file, getSignatureFileFromString("JCAppStore", file.getAbsolutePath()));
     }
 
     @Override
@@ -74,13 +74,13 @@ public class SignatureImpl implements Signature {
     }
 
     @Override
-    public Tuple<Integer, String> verifyPGPAndReturnMessage(String author, String file, String detachedSignature) throws LocalizedSignatureException {
-        return verifyPGPAndReturnMessage(author, new File(file), new File(detachedSignature));
+    public Tuple<Integer, String> verifyPGPAndReturnMessage(String fingerprint, String file, String detachedSignature) throws LocalizedSignatureException {
+        return verifyPGPAndReturnMessage(fingerprint, new File(file), new File(detachedSignature));
     }
 
     @Override
-    public Tuple<Integer, String> verifyPGPAndReturnMessage(String author, File file, File detachedSignature) throws LocalizedSignatureException {
-        return new PGP().verifySignatureAndGetErrorMsg(author, file, detachedSignature);
+    public Tuple<Integer, String> verifyPGPAndReturnMessage(String fingerprint, File file, File detachedSignature) throws LocalizedSignatureException {
+        return new PGP().verifySignatureAndGetErrorMsg(fingerprint, file, detachedSignature);
     }
 
     private void throwIfNotExists(File f) throws LocalizedSignatureException {

--- a/src/main/java/cz/muni/crocs/appletstore/util/JsonParser.java
+++ b/src/main/java/cz/muni/crocs/appletstore/util/JsonParser.java
@@ -24,7 +24,7 @@ public interface JsonParser {
     String TAG_USAGE = "usage";
     String TAG_KEYS = "keys";
     String TAG_DEFAULT_SELECTED = "default_selected";
-    String TAG_PGP_IDENTIFIER = "pgp"; //can be email or key ID
+    String TAG_PGP_FINGERPRINT = "pgp"; //can be email or key ID
     String TAG_PGP_SIGNER = "signed_by";
     String TAG_APPLET_INSTANCE_NAMES = "applet_instance_names";
 

--- a/src/main/resources/Lang_en.properties
+++ b/src/main/resources/Lang_en.properties
@@ -402,7 +402,7 @@ pgp_specify_loc = search for GnuPG
 wait_sec = Working...
 H_verified_not_trusted = Warning: the key used for this signature is not trusted ultimately.
 H_verified_no_author = The signature was verified.
-H_verified = The integrity of this release was signed by
+H_verified_key = The integrity of this release was signed and verified using key fingerprint: <br>
 H_not_verified = Integrity of this version was not verified. It is not safe to install this version. \
   Either try to re-download the store or try to install different version or sdk.
 H_unable_to_read = The files for signature verification are blocked by another program. Make sure no other \


### PR DESCRIPTION
before the signatures were made on `signed_by` field only, now this field only specifies the file name and `pgp` contains the fingerprint